### PR TITLE
clientのベースイメージの検証

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "3333:3333"
     volumes:
       - ./client:/var/www
+      - node_modules:/var/www/node_modules
     depends_on:
       - nginx
 
@@ -51,3 +52,4 @@ services:
 volumes:
   puma_socket:
   bundle:
+  node_modules:


### PR DESCRIPTION
- node_modulesディレクトリをホストのディレクトリと同期している影響で開発サーバーの起動が遅くなっていた
- なので、ホストのディレクトリとの共有を解除した
- 結果としては、Dockerリソースとコンテナでnode_modulesを同期している
- イメージの影響ではなかったため、イメージの変更はなし