### PR TITLE
ヘッダーのHPの表記を削除

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -43,7 +43,6 @@ const Battle: React.FC<Props> = (props) => {
       <CustomAppBar position='static'>
         <Toolbar>
           <CustomTypography variant="h6">プレイヤー</CustomTypography>
-          <Typography variant="h6">50/50</Typography>
         </Toolbar>
       </CustomAppBar>
       <Container fixed>


### PR DESCRIPTION
- HPはプレイヤーのHPバー付近に配置するので、ヘッダー上に必要ない