### PR TITLE
api側で標準出力でのログ出力を止める

### DIFF
--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.logger = Logger.new(STDOUT)
+  # config.logger = Logger.new(STDOUT)
 end


### PR DESCRIPTION
- マイグレーションやタスク実行時にDBへのアクセスのログが出力されてうっとしいので標準出力でのログ出力を止める
- おそらくbinding.pryのログ出力の時に設定したやつで消し忘れ
- binding.pryのログ出力はdokcer-compose.ymlで設定済み
```
D, [2022-05-16T08:13:43.324272 #334] DEBUG -- :    (0.5ms)  SET NAMES utf8,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
D, [2022-05-16T08:13:43.324961 #334] DEBUG -- :   ↳ lib/tasks/create_recode.rake:14
```