### PR TITLE
敵のデータを追加できるバッチの作成

### DIFF
--- a/api/db/migrate/20220515020833_create_players.rb
+++ b/api/db/migrate/20220515020833_create_players.rb
@@ -1,6 +1,6 @@
 class CreatePlayers < ActiveRecord::Migration[5.2]
   def change
-    create_table :players do |t|
+    create_table :players, options: "DEFAULT CHARSET=utf8mb4" do |t|
       t.string :name, null: false
       t.string :image_url, null: false
       t.integer :hp, null: false

--- a/api/db/migrate/20220515022936_create_enemies.rb
+++ b/api/db/migrate/20220515022936_create_enemies.rb
@@ -1,6 +1,6 @@
 class CreateEnemies < ActiveRecord::Migration[5.2]
   def change
-    create_table :enemies do |t|
+    create_table :enemies, options: "DEFAULT CHARSET=utf8mb4" do |t|
       t.string :name, null: false
       t.string :image_url, null: false
       t.integer :hp, null: false

--- a/api/db/migrate/20220515023826_create_cards.rb
+++ b/api/db/migrate/20220515023826_create_cards.rb
@@ -1,6 +1,6 @@
 class CreateCards < ActiveRecord::Migration[5.2]
   def change
-    create_table :cards do |t|
+    create_table :cards, options: "DEFAULT CHARSET=utf8mb4" do |t|
       t.string :name, null: false
       t.text :description, null: false
       t.string :image_url, null: false

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2022_05_15_023826) do
 
-  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
     t.string "image_url", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2022_05_15_023826) do
     t.index ["player_id"], name: "index_cards_on_player_id"
   end
 
-  create_table "enemies", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "enemies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "image_url", null: false
     t.integer "hp", null: false
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2022_05_15_023826) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "players", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "players", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "image_url", null: false
     t.integer "hp", null: false

--- a/api/lib/tasks/create_recode.rake
+++ b/api/lib/tasks/create_recode.rake
@@ -1,8 +1,8 @@
 require 'csv'
 
 # レコード作成用タスク
-namespace :create_recode do
-  desc "create players recode"
+namespace :create_record do
+  desc "create players record"
   task players: :environment do
     begin
       csv_path = Rails.root.join("tmp/player_data.csv")
@@ -22,6 +22,29 @@ namespace :create_recode do
           energy: data['energy']
         )
         player.save!
+      end
+    end
+  end
+
+  desc "create enemies record"
+  task enemies: :environment do
+    begin
+      csv_path = Rails.root.join("tmp/enemy_data.csv")
+    rescue
+      puts "ファイルが存在していません"
+      return
+    end
+
+    ActiveRecord::Base.transaction do
+      CSV.foreach(csv_path, headers: true) do |data|
+        enemy = Enemy.new(
+          name: data['name'],
+          image_url: data['image_url'],
+          hp: data['hp'],
+          attack: data['attack'],
+          defense: data['defense']
+        )
+        enemy.save!
       end
     end
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - "3306:3306"
     volumes:
       - ./docker/db/mysql_data:/var/lib/mysql
+      - ./docker/db/mysql.cnf:/etc/mysql/conf.d/mysql.cnf
 
 volumes:
   puma_socket:

--- a/docker/db/mysql.cnf
+++ b/docker/db/mysql.cnf
@@ -1,0 +1,7 @@
+[mysql]
+default_character_set = utf8mb4
+[mysqld]
+character_set_server = utf8mb4
+collation_server = utf8mb4_bin
+[client]
+default-character-set = utf8


### PR DESCRIPTION
- 敵のデータを追加できるバッチを作成する
- mysql.cnfの作成、同期（DBの文字コードをutf8mb4に設定）
- テーブル再構築（各テーブルの文字コードをutf8mb4に変更）