### PR TITLE
mysql.cnfの設定を修正

### DIFF
--- a/docker/db/mysql.cnf
+++ b/docker/db/mysql.cnf
@@ -1,5 +1,3 @@
-[mysql]
-default_character_set = utf8mb4
 [mysqld]
 character_set_server = utf8mb4
 collation_server = utf8mb4_bin


### PR DESCRIPTION
- 現在使用しているDockerイメージはmysqldコマンドを使用しているので、mysqlセクションの設定は不要のため削除する
- mysqldとclientで別途設定をするのでmysqlセクションは不要