### PR TITLE
api、dbコンテナのタイムゾーンを変更

### DIFF
--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -17,7 +17,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Www
+module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
@@ -31,5 +31,8 @@ module Www
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
   end
 end

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -2,6 +2,8 @@ FROM ruby:2.5.3
 
 WORKDIR /var/www
 
+ENV TZ Asia/Tokyo
+
 RUN apt update && \
   apt install -y build-essential nodejs
 


### PR DESCRIPTION
- apiとdbコンテナが日本時間になっていないので、日本時間に設定する