### PR TITLE
墓地アイコンを右端に固定する

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -58,9 +58,9 @@ const Battle = (props: Props): JSX.Element => {
     setDrawButtonDisable(true)
   }
 
-  const defaultNameplate = (): JSX.Element[] => {
+  const displayNameplate = (): JSX.Element[] => {
     return nameplate.map((card, index) =>
-      <Grid item xs={2} key={index}>
+      <Grid item xs={1} key={index}>
         <Card card={card} />
       </Grid>
     )
@@ -115,13 +115,9 @@ const Battle = (props: Props): JSX.Element => {
         </Grid>
 
         <Grid container className='card-list'>
-          <Grid item xs={1}>
-            <div className='deck'></div>
-          </Grid>
-          { defaultNameplate() }
-          <Grid item xs={1}>
-            <div className='cemetery'></div>
-          </Grid>
+          <div className='deck'></div>
+          { displayNameplate() }
+          <div className='cemetery'></div>
         </Grid>
 
       </Container>

--- a/client/src/components/battle/card.tsx
+++ b/client/src/components/battle/card.tsx
@@ -18,6 +18,10 @@ type Props = {
   }
 }
 
+const CustomCardContainer = styled(CardContainer)({
+  marginRight: 5
+})
+
 const CustomCardHeader = styled(CardHeader)({
   color: "white",
   backgroundColor: "black",
@@ -27,7 +31,7 @@ const CustomCardHeader = styled(CardHeader)({
 const Card = (props: Props): JSX.Element => {
   const { card } = props
   return (
-    <CardContainer sx={{ maxWidth: 100, maxHeight: 150 }}>
+    <CustomCardContainer sx={{ maxWidth: 100, maxHeight: 150 }}>
       <CustomCardHeader
         disableTypography
         subheader={<Typography variant="body2">{card.name}</Typography>}
@@ -43,7 +47,7 @@ const Card = (props: Props): JSX.Element => {
           {card.description}
         </Typography>
       </CardContent>
-    </CardContainer>
+    </CustomCardContainer>
   )
 }
 

--- a/client/src/styles/battle/style.scss
+++ b/client/src/styles/battle/style.scss
@@ -35,6 +35,7 @@
 
 .card-list {
   margin-top: 30px;
+  justify-content: center;
 }
 
 .deck, .cemetery {
@@ -46,6 +47,10 @@
   height: 76px;
   border-radius: 2px;
   border: solid 1px currentColor;
+}
+
+.deck {
+  left: 50px
 }
 
 .deck:before {
@@ -68,6 +73,10 @@
   height: 76px;
   border-top: solid 2px currentColor;
   border-left: solid 2px currentColor;
+}
+
+.cemetery {
+  right: 50px;
 }
 
 .cemetery:before {


### PR DESCRIPTION
- 手札の枚数に応じて墓地アイコンが左詰めにされているので、右端に固定する