### PR TITLE
ターン終了機能の作成

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -111,6 +111,12 @@ const Battle = (props: Props): JSX.Element => {
     }
   }
 
+  const turnEnd = (): void => {
+    setIsPlayerTurn(false)
+    setCemetery(nameplate)
+    setNameplate([])
+  }
+
   const selectCard = (card: CardType): void => {
     setConfirmCard(card)
     handleOpen()
@@ -161,7 +167,7 @@ const Battle = (props: Props): JSX.Element => {
         </Grid>
 
         <Grid container className='draw-button'>
-          <Grid item xs={12}>
+          <Grid item xs={6}>
             <Button
               variant="contained"
               color="success"
@@ -170,6 +176,17 @@ const Battle = (props: Props): JSX.Element => {
               disabled={ drawButtonDisable ? true : false }
             >
               ドロー
+            </Button>
+          </Grid>
+          <Grid item xs={6} className='turn-end'>
+            <Button
+              variant="contained"
+              color="inherit"
+              size="small"
+              onClick={turnEnd}
+              disabled={ isPlayerTurn ? false : true }
+            >
+              ターン終了
             </Button>
           </Grid>
         </Grid>

--- a/client/src/styles/battle/style.scss
+++ b/client/src/styles/battle/style.scss
@@ -125,3 +125,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
 }
+
+.turn-end {
+  text-align: right;
+}


### PR DESCRIPTION
- ターン終了ボタンを表示させる
- ターン終了ボタンを押したらターンのステータスを相手に移す
- 手札を全て墓地に移動させる