### PR TITLE
プレイヤーの情報がなかったら空白にする

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -130,7 +130,7 @@ const Battle = (props: Props): JSX.Element => {
       <CustomAppBar position='static'>
         <Toolbar>
           <CustomTypography variant="h6">プレイヤー</CustomTypography>
-          <Typography variant="h6">{player.name}</Typography>
+          <Typography variant="h6">{player && player.name}</Typography>
         </Toolbar>
       </CustomAppBar>
 
@@ -147,7 +147,7 @@ const Battle = (props: Props): JSX.Element => {
             <img src={playerImg} alt='プレイヤー' className='player-img' />
             <CustomLinearProgress variant="determinate" value={hpAdjustment(player.hp)}/>
             <Typography variant="subtitle1" component="div">
-              {player.hp}/{HP_MAX}
+              {player && player.hp}/{HP_MAX}
             </Typography>
           </Grid>
           <Grid item xs={6} className='enemy'>
@@ -161,7 +161,7 @@ const Battle = (props: Props): JSX.Element => {
 
         <Grid container className='energy'>
           <Grid item xs={12}>
-            {player.energy}/{ENERGY_MAX}
+            {player && player.energy}/{ENERGY_MAX}
           </Grid>
         </Grid>
 


### PR DESCRIPTION
- Stateに初期値を設定しないと、最初のレンダリングでデータがないとエラーが出る
- エラー対応として、データがない場合は空白にするように修正する