### PR TITLE
レンダリング時に敵の情報がなかったら空白にする

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,14 +11,7 @@ const App = (): JSX.Element => {
   const [gameTitleDisable, setGameTitleDisable] = useState(false)
   const [rootSelectDisable, setRootSelectDisable] = useState(true)
   const [battleDisable, setBattleDisable] = useState(true)
-  const [enemies, setEnemies] = useState<EnemyType[]>([{
-    id: 0,
-    name: "",
-    imageUrl: "",
-    hp: 0,
-    attack: 0,
-    defense: 0
-  }])
+  const [enemies, setEnemies] = useState<EnemyType[]>([])
   const [player, setPlayer] = useState<PlayerType>({
     name: "",
     imageUrl: "",

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -125,6 +125,10 @@ const Battle = (props: Props): JSX.Element => {
     console.log("カード実行処理")
   }
 
+  const isBlankEnemies = (): boolean => {
+    return enemies.length === 0 ? true : false
+  }
+
   return (
     <div style={{ display: disable ? 'none' : '' }}>
       <CustomAppBar position='static'>
@@ -152,9 +156,9 @@ const Battle = (props: Props): JSX.Element => {
           </Grid>
           <Grid item xs={6} className='enemy'>
             <img src={enemyImg} alt='敵' className='enemy-img' />
-            <CustomLinearProgress variant="determinate" value={hpAdjustment(enemies[0].hp)}/>
+            <CustomLinearProgress variant="determinate" value={hpAdjustment(isBlankEnemies() ? 0 : enemies[0].hp)}/>
             <Typography variant="subtitle1" component="div">
-              {enemies[0].hp}/{enemies[0].hp}
+              {isBlankEnemies() ? 0 : enemies[0].hp}/{isBlankEnemies() ? 0 : enemies[0].hp}
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
- 初期レンダリング時に敵のデータが存在しない場合があるため、エラー対応を行う
- APIを叩く前のエラー対策