### PR TITLE
カードモデルにaction_nameカラムを追加する

### DIFF
--- a/api/db/migrate/20220525140859_add_action_name_to_cards.rb
+++ b/api/db/migrate/20220525140859_add_action_name_to_cards.rb
@@ -1,0 +1,9 @@
+class AddActionNameToCards < ActiveRecord::Migration[5.2]
+  def up
+    add_column :cards, :action_name, :string, null: false, after: :defense
+  end
+
+  def down
+    remove_column :cards, :action_name, :string, null: false, after: :defense
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_17_024755) do
+ActiveRecord::Schema.define(version: 2022_05_25_140859) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2022_05_17_024755) do
     t.string "card_type", null: false
     t.integer "attack", null: false
     t.integer "defense", null: false
+    t.string "action_name", null: false
     t.bigint "player_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
- カードの能力を実行するためのキー名を格納するカラムを作成する
- action_nameをclient側に渡してそれをキーにして、カードの能力を発動させる
- カードの能力自体はclient側で定義する。あくまでカードを発動させるためのキー名をカラムに格納する