### PR TITLE
カードのアクションリストの作成

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,7 @@ import { initializeDeck } from './battle/deck'
 import GameTitle from './components/gameTitle'
 import RootSelect from './components/rootSelect'
 import Battle from './components/battle'
-import { PlayerType, EnemyType, CardType } from './types/model'
+import { PlayerType, EnemyType, CardType } from './types/model/index'
 import { ResPlayer, ResEnemies, ResCards } from './types/api/response'
 
 const App = (): JSX.Element => {
@@ -84,7 +84,8 @@ const App = (): JSX.Element => {
           cost: card.cost,
           cardType: card.card_type,
           attack: card.attack,
-          defense: card.defense
+          defense: card.defense,
+          actionName: card.action_name
         }
       })
       setCards(newCards)

--- a/client/src/battle/cardEffectList.ts
+++ b/client/src/battle/cardEffectList.ts
@@ -1,0 +1,21 @@
+import { PlayerType, EnemyType, CardType } from '../types/model'
+import { cardEffect } from '../types/battle/cardEffect'
+
+export const cardEffectList: cardEffect[] = [
+  {
+    name: "strike",
+    execution: (player: PlayerType, enemies: EnemyType[], card: CardType) => strike(player, enemies[0], card)
+  },
+  {
+    name: "protection",
+    execution: (player: PlayerType, enemies: EnemyType[], card: CardType) => protection(player, card)
+  }
+]
+
+const strike = (player: PlayerType, enemy: EnemyType, card: CardType): void => {
+  console.log("ストライク")
+}
+
+const protection = (player: PlayerType, card: CardType): void => {
+  console.log("ぼうぎょ")
+}

--- a/client/src/battle/deck.ts
+++ b/client/src/battle/deck.ts
@@ -1,4 +1,4 @@
-import { CardType } from '../types/model'
+import { CardType } from '../types/model/index'
 
 export const initializeDeck = (cardList: CardType[]): CardType[] => {
   let defaultDeck: CardType[] = []

--- a/client/src/battle/index.ts
+++ b/client/src/battle/index.ts
@@ -1,0 +1,18 @@
+import { PlayerType, EnemyType, CardType } from '../types/model/index'
+import { cardEffect } from '../types/battle/cardEffect'
+import { cardEffectList } from './cardEffectList'
+
+export const playerAction = (player: PlayerType, enemies: EnemyType[], card: CardType): void => {
+  const cardEffectObj = searchCardEffect(card.actionName)
+  if (cardEffectObj === null) {
+    console.log("実行できるアクションが存在しません")
+    return
+  }
+  cardEffectObj.execution(player, enemies, card)
+}
+
+const searchCardEffect = (actionName: string): cardEffect | null => {
+  const cardEffectObj = cardEffectList.find(item => item.name === actionName)
+  if (cardEffectObj === undefined) { return null }
+  return cardEffectObj
+}

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -11,9 +11,10 @@ import Avatar from '@mui/material/Avatar'
 import Paper from '@mui/material/Paper'
 import Modal from '@mui/material/Modal'
 import LinearProgress from '@mui/material/LinearProgress'
+import { PlayerType, EnemyType, CardType } from '../types/model/index'
 import Card from '../components/battle/card'
 import ModalCard from '../components/battle/modalCard'
-import { PlayerType, EnemyType, CardType } from '../types/model'
+import { playerAction } from '../battle/index'
 import playerImg from '../images/player.png'
 import enemyImg from '../images/enemy.png'
 import '../styles/battle/style.scss'
@@ -57,7 +58,6 @@ const CustomLinearProgress = styled(LinearProgress)({
   margin: "auto"
 })
 
-
 const Battle = (props: Props): JSX.Element => {
   const { disable, enemies, player, deck } = props
   const [drawButtonDisable, setDrawButtonDisable] = useState<boolean>(false)
@@ -72,7 +72,8 @@ const Battle = (props: Props): JSX.Element => {
     cost: 0,
     cardType: "",
     attack: 0,
-    defense: 0
+    defense: 0,
+    actionName: ""
   })
 
   const handleOpen = (): void => setOpen(true)
@@ -122,7 +123,7 @@ const Battle = (props: Props): JSX.Element => {
   }
 
   const actionCard = (card: CardType): void => {
-    console.log("カード実行処理")
+    playerAction(player, enemies, card)
   }
 
   const isBlankEnemies = (): boolean => {

--- a/client/src/components/battle/card.tsx
+++ b/client/src/components/battle/card.tsx
@@ -5,7 +5,7 @@ import CardHeader from '@mui/material/CardHeader'
 import CardMedia from '@mui/material/CardMedia'
 import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
-import { CardType } from '../../types/model'
+import { CardType } from '../../types/model/index'
 import playerImg from '../../images/player.png'
 
 type Props = {

--- a/client/src/components/battle/modalCard.tsx
+++ b/client/src/components/battle/modalCard.tsx
@@ -1,5 +1,5 @@
 import Card from './card'
-import { CardType } from '../../types/model'
+import { CardType } from '../../types/model/index'
 
 type Props = {
   card: CardType

--- a/client/src/types/api/response.d.ts
+++ b/client/src/types/api/response.d.ts
@@ -25,4 +25,5 @@ export type ResCards = {
   card_type: string
   attack: number
   defense: number
+  action_name: string
 }

--- a/client/src/types/battle/cardEffect.d.ts
+++ b/client/src/types/battle/cardEffect.d.ts
@@ -1,0 +1,4 @@
+export type cardEffect = {
+  name: string
+  execution: (player: PlayerType, enemies: EnemyType[], card: CardType) => void
+}

--- a/client/src/types/model/index.d.ts
+++ b/client/src/types/model/index.d.ts
@@ -24,4 +24,5 @@ export type CardType = {
   cardType: string
   attack: number
   defense: number
+  actionName: string
 }


### PR DESCRIPTION
- APIからaction_nameを取得
- 型の変更（action_nameを追加）
- ストライクの関数を作成
- カードのアクションをまとめる配列を作成
- ストライク関数を配列に格納
- カード名をキーとして、呼び出せるか確認する
- ストライクとぼうぎょを区別して実行できることを確認した
- ストライクとぼうぎょの実装は別issueで対応する