### PR TITLE
カードの効果を発動したらカードを墓地に移動する

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,7 @@ import { initializeDeck } from './battle/deck'
 import GameTitle from './components/gameTitle'
 import RootSelect from './components/rootSelect'
 import Battle from './components/battle'
-import { PlayerType, EnemyType, CardType } from './types/model/index'
+import { PlayerType, EnemyType, CardBaseType } from './types/model/index'
 import { ResPlayer, ResEnemies, ResCards } from './types/api/response'
 
 const App = (): JSX.Element => {
@@ -12,7 +12,7 @@ const App = (): JSX.Element => {
   const [rootSelectDisable, setRootSelectDisable] = useState(true)
   const [battleDisable, setBattleDisable] = useState(true)
   const [enemies, setEnemies] = useState<EnemyType[]>([])
-  const [cards, setCards] = useState<CardType[]>([])
+  const [cards, setCards] = useState<CardBaseType[]>([])
   const [player, setPlayer] = useState<PlayerType>({
     name: "",
     imageUrl: "",
@@ -80,7 +80,7 @@ const App = (): JSX.Element => {
     await axios.get(`${process.env.REACT_APP_API_URL_BROWSER}/v1/cards`)
     .then(res => {
       const resCards: ResCards[] = res.data
-      const newCards: CardType[] = resCards.map((card: ResCards) => {
+      const newCards: CardBaseType[] = resCards.map((card: ResCards) => {
         return {
           name: card.name,
           description: card.description,

--- a/client/src/battle/deck.ts
+++ b/client/src/battle/deck.ts
@@ -1,17 +1,40 @@
-import { CardType } from '../types/model/index'
+import { CardBaseType, CardType } from '../types/model/index'
 
-export const initializeDeck = (cardList: CardType[]): CardType[] => {
+export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
   let defaultDeck: CardType[] = []
-  const strike: CardType | undefined = cardList.find((card: CardType) => card.name === "ストライク")
-  const protection: CardType | undefined = cardList.find((card: CardType) => card.name === "ぼうぎょ")
+  let cardId = 1
+  const strike: CardBaseType | undefined = cardList.find((card: CardBaseType) => card.name === "ストライク")
+  const protection: CardBaseType | undefined = cardList.find((card: CardBaseType) => card.name === "ぼうぎょ")
   if (strike !== undefined) {
     for (let i = 0; i < 5; i++) {
-      defaultDeck.push(strike)
+      defaultDeck.push({
+        id: cardId,
+        name: strike.name,
+        description: strike.description,
+        imageUrl: strike.imageUrl,
+        cost: strike.cost,
+        cardType: strike.cardType,
+        attack: strike.attack,
+        defense: strike.defense,
+        actionName: strike.actionName
+      })
+      cardId += 1
     }
   }
   if (protection !== undefined) {
     for (let i = 0; i < 5; i++) {
-      defaultDeck.push(protection)
+      defaultDeck.push({
+        id: cardId,
+        name: protection.name,
+        description: protection.description,
+        imageUrl: protection.imageUrl,
+        cost: protection.cost,
+        cardType: protection.cardType,
+        attack: protection.attack,
+        defense: protection.defense,
+        actionName: protection.actionName
+      })
+      cardId += 1
     }
   }
   defaultDeck = deckShuffle(defaultDeck)

--- a/client/src/battle/index.ts
+++ b/client/src/battle/index.ts
@@ -9,6 +9,13 @@ export const playerAction = (player: PlayerType, enemies: EnemyType[], card: Car
     return
   }
   cardEffectObj.execution(player, enemies, card)
+
+  player.nameplate.forEach((nameplate, index) => {
+    if (nameplate.id === card.id) {
+      player.cemetery.push(nameplate)
+      player.nameplate.splice(index, 1)
+    }
+  })
 }
 
 const searchCardEffect = (actionName: string): cardEffect | null => {

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -63,6 +63,7 @@ const Battle = (props: Props): JSX.Element => {
   const [isPlayerTurn, setIsPlayerTurn] = useState<boolean>(true)
   const [open, setOpen] = useState<boolean>(false)
   const [confirmCard, setConfirmCard] = useState<CardType>({
+    id: 0,
     name: "",
     description: "",
     imageUrl: "",

--- a/client/src/types/model/index.d.ts
+++ b/client/src/types/model/index.d.ts
@@ -19,7 +19,19 @@ export type PlayerType = {
   cemetery: CardType[]
 }
 
+export type CardBaseType = {
+  name: string
+  description: string
+  imageUrl: string
+  cost: number
+  cardType: string
+  attack: number
+  defense: number
+  actionName: string
+}
+
 export type CardType = {
+  id: number
   name: string
   description: string
   imageUrl: string


### PR DESCRIPTION
- CardBaseTypeの追加（idがないCardType型）
- CardTypeにidパラメーターを付与
- cardにIDを付与して、使用したカードを識別できるようにした
- 発動したカードを墓地に追加
- カードの効果を発動したカードを手札から削除