### PR TITLE
敵の行動が終了したらプレイヤーのターンにする

### DIFF
--- a/client/src/battle/player.ts
+++ b/client/src/battle/player.ts
@@ -29,6 +29,10 @@ export const cardDraw = (player: PlayerType): void => {
   player.nameplate = player.nameplate.concat(nameplate)
 }
 
+export const recoveryEnergy = (player: PlayerType, maxEnergy: number): void => {
+  player.energy = maxEnergy
+}
+
 const searchCardEffect = (actionName: string): cardEffect | null => {
   const cardEffectObj = cardEffectList.find(item => item.name === actionName)
   if (cardEffectObj === undefined) { return null }

--- a/client/src/common/battle.ts
+++ b/client/src/common/battle.ts
@@ -15,6 +15,8 @@ export const addBlock = (player: PlayerType, card: CardType): void => {
   player.defense += card.defense
 }
 
+export const sleep = (msec: number) => new Promise(resolve => setTimeout(resolve, msec))
+
 const calcDamage = (attackPoint: number, defensePoint: number): number => {
   const diff = defensePoint - attackPoint
   const damage = diff < 0 ? Math.abs(diff) : 0

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -14,7 +14,8 @@ import LinearProgress from '@mui/material/LinearProgress'
 import { PlayerType, EnemyType, CardType } from '../types/model/index'
 import Card from '../components/battle/card'
 import ModalCard from '../components/battle/modalCard'
-import { playerAction, cardDraw } from '../battle/player'
+import { sleep } from '../common/battle'
+import { playerAction, cardDraw, recoveryEnergy } from '../battle/player'
 import { enemyAction } from '../battle/enemy'
 import playerImg from '../images/player.png'
 import enemyImg from '../images/enemy.png'
@@ -124,8 +125,16 @@ const Battle = (props: Props): JSX.Element => {
     return enemies.length === 0 ? true : false
   }
 
-  const enemyTurn = (): void => {
+  const enemyTurn = async (): Promise<void> => {
+    await sleep(2000)
     enemyAction(player, enemies)
+    enemyTurnEnd()
+  }
+
+  const enemyTurnEnd = (): void => {
+    setIsPlayerTurn(true)
+    setDrawButtonDisable(false)
+    recoveryEnergy(player, ENERGY_MAX)
   }
 
   return (


### PR DESCRIPTION
- 敵のターンエンド処理を追加
- カードをドローできるようにする
- エナジーを回復する
- ターン終了ボタンを選択できるようにする