### PR TITLE
デッキにカードを戻す処理の追加

### DIFF
--- a/client/src/battle/deck.ts
+++ b/client/src/battle/deck.ts
@@ -1,4 +1,5 @@
 import { CardBaseType, CardType } from '../types/model/index'
+import { deckShuffle } from '../common/battle'
 
 export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
   let defaultDeck: CardType[] = []
@@ -39,14 +40,4 @@ export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
   }
   defaultDeck = deckShuffle(defaultDeck)
   return defaultDeck
-}
-
-const deckShuffle = (deck: CardType[]): CardType[] => {
-  for (let i = deck.length - 1; i > 0; i--) {
-    const r = Math.floor(Math.random() * (i + 1))
-    const tmp = deck[i]
-    deck[i] = deck[r]
-    deck[r] = tmp
-  }
-  return deck
 }

--- a/client/src/battle/player.ts
+++ b/client/src/battle/player.ts
@@ -1,5 +1,6 @@
 import { PlayerType, EnemyType, CardType } from '../types/model/index'
 import { cardEffect } from '../types/battle/cardEffect'
+import { deckShuffle } from '../common/battle'
 import { cardEffectList } from './cardEffectList'
 
 export const playerAction = (player: PlayerType, enemies: EnemyType[], card: CardType): void => {
@@ -18,14 +19,15 @@ export const playerAction = (player: PlayerType, enemies: EnemyType[], card: Car
   }
 }
 
-export const cardDraw = (player: PlayerType): void => {
+export const cardDraw = (player: PlayerType, drawNum: number): void => {
   const nameplate: CardType[] = []
+  if (player.deck.length < drawNum) { recoveryDeck(player) }
   player.deck.forEach((card, i) => {
-    if (i < 5) {
+    if (i < drawNum) {
       nameplate.push(card)
     }
   })
-  player.deck.splice(0, 5)
+  player.deck.splice(0, drawNum)
   player.nameplate = player.nameplate.concat(nameplate)
 }
 
@@ -55,4 +57,10 @@ const moveNameplateToCemetery = (player: PlayerType, card: CardType): void => {
       player.nameplate.splice(index, 1)
     }
   })
+}
+
+const recoveryDeck = (player: PlayerType): void => {
+  player.deck = player.deck.concat(player.cemetery)
+  player.deck = deckShuffle(player.deck)
+  player.cemetery = []
 }

--- a/client/src/common/battle.ts
+++ b/client/src/common/battle.ts
@@ -17,6 +17,16 @@ export const addBlock = (player: PlayerType, card: CardType): void => {
 
 export const sleep = (msec: number) => new Promise(resolve => setTimeout(resolve, msec))
 
+export const deckShuffle = (deck: CardType[]): CardType[] => {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const r = Math.floor(Math.random() * (i + 1))
+    const tmp = deck[i]
+    deck[i] = deck[r]
+    deck[r] = tmp
+  }
+  return deck
+}
+
 const calcDamage = (attackPoint: number, defensePoint: number): number => {
   const diff = defensePoint - attackPoint
   const damage = diff < 0 ? Math.abs(diff) : 0

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -80,7 +80,7 @@ const Battle = (props: Props): JSX.Element => {
   const handleClose = (): void => setOpen(false)
 
   const onClickDraw = (): void => {
-    cardDraw(player)
+    cardDraw(player, 5)
     setDrawButtonDisable(true)
   }
 


### PR DESCRIPTION
- ドローする枚数よりデッキの枚数が少ない場合、墓地のカードをデッキに戻す
- デッキにカードを戻したらシャッフルする
- その後にドローする