### PR TITLE
敵が全滅したらルート選択画面に戻る

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -38,6 +38,11 @@ const App = (): JSX.Element => {
     setBattleDisable(false)
   }
 
+  const victory = (): void => {
+    setBattleDisable(true)
+    setRootSelectDisable(false)
+  }
+
   const getEnemies = async (): Promise<void> => {
     await axios.get(`${process.env.REACT_APP_API_URL_BROWSER}/v1/enemies`)
     .then(res => {
@@ -131,6 +136,7 @@ const App = (): JSX.Element => {
         disable={battleDisable}
         enemies={fightEnemies}
         player={player}
+        victory={victory}
       />
     </div>
   )

--- a/client/src/battle/enemy.ts
+++ b/client/src/battle/enemy.ts
@@ -14,3 +14,7 @@ export const checkRemainingHp = (enemies: EnemyType[]): void => {
     }
   })
 }
+
+export const isExistEnemy = (enemies: EnemyType[]): boolean => {
+  return enemies.length > 0 ? true : false
+}

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -16,7 +16,7 @@ import Card from '../components/battle/card'
 import ModalCard from '../components/battle/modalCard'
 import { sleep } from '../common/battle'
 import { playerAction, cardDraw, recoveryEnergy } from '../battle/player'
-import { enemyAction, checkRemainingHp } from '../battle/enemy'
+import { enemyAction, checkRemainingHp, isExistEnemy } from '../battle/enemy'
 import playerImg from '../images/player.png'
 import enemyImg from '../images/enemy.png'
 import '../styles/battle/style.scss'
@@ -25,6 +25,7 @@ type Props = {
   disable: boolean
   enemies: EnemyType[]
   player: PlayerType
+  victory: () => void
 }
 
 const ENERGY_MAX = 3
@@ -60,7 +61,7 @@ const CustomLinearProgress = styled(LinearProgress)({
 })
 
 const Battle = (props: Props): JSX.Element => {
-  const { disable, enemies, player } = props
+  const { disable, enemies, player, victory } = props
   const [drawButtonDisable, setDrawButtonDisable] = useState<boolean>(false)
   const [isPlayerTurn, setIsPlayerTurn] = useState<boolean>(true)
   const [open, setOpen] = useState<boolean>(false)
@@ -133,6 +134,7 @@ const Battle = (props: Props): JSX.Element => {
   const actionCard = (card: CardType): void => {
     playerAction(player, enemies, card)
     checkRemainingHp(enemies)
+    if (!isExistEnemy(enemies)) { victory() }
     handleClose()
   }
 


### PR DESCRIPTION
- プレイヤーの行動後に敵の数を確認
- 敵の数が0だったらバトル画面を非表示にして、ルート選択画面を表示させる