### PR TITLE
大元の敵情報とバトル用の敵情報が共有しないようにする

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -41,7 +41,8 @@ const App = (): JSX.Element => {
   }
 
   const decisionFightEnemies = (rootNumber: number): void => {
-    const enemyList: EnemyList = createEnemyList(enemies)
+    const parseEnemies = JSON.parse(JSON.stringify(enemies))
+    const enemyList: EnemyList = createEnemyList(parseEnemies)
     switch (rootNumber) {
       case 0:
         setFightEnemies(enemyList.slime)


### PR DESCRIPTION
- 大元の敵情報から値だけをコピーした変数を作成
- その変数を元にバトル用敵情報を作成
- バトルを行っても大元の敵情報のステータスが変更されないことを確認済み
- 2回目以降のバトルも敵のHPが初期状態からスタートしていることを確認済み