### PR TITLE
選択できるステージの制限を設定

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ const App = (): JSX.Element => {
     attack: 0,
     defense: 0,
     energy: 0,
+    stage: 0,
     deck: [],
     nameplate: [],
     cemetery: []
@@ -35,10 +36,13 @@ const App = (): JSX.Element => {
     setRootSelectDisable(false)
   }
 
-  const battleStart = (rootNumber: number): void => {
-    decisionFightEnemies(rootNumber)
-    setRootSelectDisable(true)
-    setBattleDisable(false)
+  const battleStart = (rootNumber: number, playerStage: number): void => {
+    // 次のステージを選択した時のみバトルを開始する
+    if (playerStage === rootNumber) {
+      decisionFightEnemies(rootNumber)
+      setRootSelectDisable(true)
+      setBattleDisable(false)
+    }
   }
 
   const decisionFightEnemies = (rootNumber: number): void => {
@@ -67,6 +71,7 @@ const App = (): JSX.Element => {
   }
 
   const victory = (): void => {
+    setPlayer(player => ({ ...player, stage: player.stage + 1 }))
     setBattleDisable(true)
     setRootSelectDisable(false)
   }
@@ -113,6 +118,7 @@ const App = (): JSX.Element => {
         attack: resPlayer.attack,
         defense: resPlayer.defense,
         energy: resPlayer.energy,
+        stage: 0,
         deck: [],
         nameplate: [],
         cemetery: []
@@ -164,6 +170,7 @@ const App = (): JSX.Element => {
       />
       <RootSelect
         disable={rootSelectDisable}
+        playerStage={player.stage}
         onClick={battleStart}
       />
       <Battle

--- a/client/src/components/rootSelect.tsx
+++ b/client/src/components/rootSelect.tsx
@@ -2,11 +2,24 @@ import Container from '@mui/material/Container'
 import Circle from './root_select/circle'
 import Line from './root_select/line'
 import { Click, Position } from '../types/root_select/index'
+import playerImg from '../images/player.png'
+import '../styles/battle/style.scss'
 
 type Props = {
   disable: boolean
-  onClick: (rootNumber: number) => void
+  playerStage: number
+  onClick: (rootNumber: number, playerStage: number) => void
 }
+
+const playerPosition: Position = [
+  { left: 2, top: 90 }, // スタート
+  { left: 10, top: 90 }, // ステージ1
+  { left: 25, top: 90 }, // ステージ2
+  { left: 40, top: 90 }, // ステージ3
+  { left: 55, top: 90 }, // ステージ4
+  { left: 70, top: 90 }, // ステージ5
+  { left: 85, top: 90 }  // ステージ6
+]
 
 const circlePosition: Position = [
   { left: 10, top: 200 }, // 1列目
@@ -26,7 +39,7 @@ const linePosition: Position = [
 ]
 
 const Circles = (props: Click): JSX.Element => {
-  const { onClick } = props
+  const { playerStage, onClick } = props
 
   const circles = circlePosition.map((pos, index) =>
     <Circle
@@ -34,6 +47,7 @@ const Circles = (props: Click): JSX.Element => {
       top={pos.top}
       key={index}
       rootNumber={index}
+      playerStage={playerStage}
       onClick={onClick}
     />
   )
@@ -48,12 +62,18 @@ const Lines = (): JSX.Element => {
 }
 
 const RootSelect = (props: Props): JSX.Element => {
-  const { disable, onClick } = props
+  const { disable, playerStage, onClick } = props
 
   return (
     <div style={{ display: disable ? 'none' : '' }}>
       <Container fixed>
-        <Circles onClick={onClick} />
+        <img
+          src={playerImg}
+          alt="プレイヤー"
+          className='player-img'
+          style={{ position: "absolute", left: playerPosition[playerStage].left + '%', top: playerPosition[playerStage].top }}
+        />
+        <Circles playerStage={playerStage} onClick={onClick} />
         <Lines />
       </Container>
     </div>

--- a/client/src/components/root_select/circle.tsx
+++ b/client/src/components/root_select/circle.tsx
@@ -4,17 +4,18 @@ type Props = {
   left: number
   top: number
   rootNumber: number
-  onClick: (rootNumber: number) => void
+  playerStage: number
+  onClick: (rootNumber: number, playerStage: number) => void
 }
 
 const Circle = (props: Props): JSX.Element => {
-  const { left, top, rootNumber, onClick } = props
+  const { left, top, rootNumber, playerStage, onClick } = props
 
   return (
     <div
-      className='circle'
+      className={`circle ${playerStage === rootNumber ? "next-stage" : ""}`}
       style={{ left: left + '%', top: top }}
-      onClick={() => onClick(rootNumber)}
+      onClick={() => onClick(rootNumber, playerStage)}
     >
     </div>
   )

--- a/client/src/styles/root_select/style.scss
+++ b/client/src/styles/root_select/style.scss
@@ -10,3 +10,20 @@
   position: absolute;
   border: 1px solid skyblue;
 }
+
+.next-stage {
+  &:hover {
+    animation: flash 1s linear infinite;
+    background-color: aqua;
+  }
+}
+
+@keyframes flash {
+  0%, 100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+}

--- a/client/src/types/model/index.d.ts
+++ b/client/src/types/model/index.d.ts
@@ -16,6 +16,7 @@ export type PlayerType = {
   attack: number
   defense: number
   energy: number
+  stage: number
   deck: CardType[]
   nameplate: CardType[]
   cemetery: CardType[]

--- a/client/src/types/root_select/index.d.ts
+++ b/client/src/types/root_select/index.d.ts
@@ -1,5 +1,6 @@
 export type Click = {
-  onClick: (rootNumber: number) => void
+  playerStage: number
+  onClick: (rootNumber: number, playerStage: number) => void
 }
 
 export type Position = {


### PR DESCRIPTION
- プレイヤーに今いるステージ数を管理するパラメータを追加
- 次のステージのみ選択できるようにした
- プレイヤーの今いるステージと選択したステージを比較できるようにデータの受け渡しを実装
- バトルに勝利したらプレイヤーの今いるステージを更新するようにした
- プレイヤーが今いるステージを可視化するためにプレイヤー画像を画面に表示
- 次のステージにカーソルを合わせると点滅するようにした