### PR TITLE
プレイヤーのステータス反映処理の修正

### DIFF
--- a/client/src/battle/player.ts
+++ b/client/src/battle/player.ts
@@ -21,3 +21,40 @@ export const isRemainsEnergy = (player: PlayerType, card: CardType): boolean => 
   const diff = player.energy - card.cost
   return diff >= 0 ? true : false
 }
+
+export const moveAllNameplateToCemetery = (player: PlayerType): void => {
+  player.cemetery = player.cemetery.concat(player.nameplate)
+  player.nameplate = []
+}
+
+export const returnCardToDeck = (player: PlayerType): void => {
+  player.deck = player.deck.concat(player.nameplate)
+  player.deck = player.deck.concat(player.cemetery)
+  player.nameplate = []
+  player.cemetery = []
+}
+
+export const recoveryEnergy = (player: PlayerType, energy: number): void => {
+  player.energy = energy
+}
+
+export const resetPlayerStatus = (player: PlayerType): void => {
+  player.defense = 0
+}
+
+export const subtractEnergy = (player: PlayerType, cardCost: number): void => {
+  player.energy -= cardCost
+}
+
+export const moveUsedCardToCemetery = (player: PlayerType, card: CardType): void => {
+  player.nameplate.forEach((nameplate, index) => {
+    if (nameplate.id === card.id) {
+      player.cemetery.push(nameplate)
+      player.nameplate.splice(index, 1)
+    }
+  })
+}
+
+export const incrementStage = (player: PlayerType): void => {
+  player.stage += 1
+}

--- a/client/src/common/battle.ts
+++ b/client/src/common/battle.ts
@@ -31,3 +31,7 @@ export const calcDamage = (attackPoint: number, defensePoint: number): number =>
   const damage = diff < 0 ? Math.abs(diff) : 0
   return damage
 }
+
+export const subtractHp = (character: PlayerType | EnemyType, damage: number): void => {
+  character.hp -= damage
+}

--- a/client/src/redux/slice/playerSlice.ts
+++ b/client/src/redux/slice/playerSlice.ts
@@ -36,9 +36,6 @@ export const playerSlice = createSlice({
     initialDeck: (state, action: PayloadAction<CardType[]>) => {
       state.deck = action.payload
     },
-    incrementStage: (state) => {
-      state.stage += 1
-    },
     cardDraw: (state, action: PayloadAction<number>) => {
       state.deck.forEach((card, i) => {
         if (i < action.payload) {
@@ -47,61 +44,25 @@ export const playerSlice = createSlice({
       })
       state.deck.splice(0, action.payload)
     },
-    moveAllNameplateToCemetery: (state) => {
-      state.cemetery = state.cemetery.concat(state.nameplate)
-      state.nameplate = []
-    },
-    moveUsedCardToCemetery: (state, action: PayloadAction<CardType>) => {
-      state.nameplate.forEach((nameplate, index) => {
-        if (nameplate.id === action.payload.id) {
-          state.cemetery.push(nameplate)
-          state.nameplate.splice(index, 1)
-        }
-      })
-    },
-    returnCardToDeck: (state) => {
-      state.deck = state.deck.concat(state.nameplate)
-      state.deck = state.deck.concat(state.cemetery)
-      state.nameplate = []
-      state.cemetery = []
-    },
     recoveryDeck: (state) => {
       state.deck = state.deck.concat(state.cemetery)
       state.deck = deckShuffle(state.deck)
       state.cemetery = []
     },
-    recoveryEnergy: (state, action: PayloadAction<number>) => {
-      state.energy = action.payload
-    },
     addDefense: (state, action: PayloadAction<number>) => {
       state.defense += action.payload
     },
-    subtractEnergy: (state, action: PayloadAction<number>) => {
-      state.energy -= action.payload
-    },
-    subtractHp: (state, action: PayloadAction<number>) => {
-      state.hp -= action.payload
-    },
-    resetPlayerStatus: (state) => {
-      state.defense = 0
-    }
+    updatePlayerStatus: (state, action: PayloadAction<PlayerType>) => action.payload
   }
 })
 
 export const {
   setPlayer,
   initialDeck,
-  incrementStage,
   cardDraw,
-  moveAllNameplateToCemetery,
-  moveUsedCardToCemetery,
-  returnCardToDeck,
   recoveryDeck,
   addDefense,
-  recoveryEnergy,
-  subtractEnergy,
-  subtractHp,
-  resetPlayerStatus
+  updatePlayerStatus
 } = playerSlice.actions
 
 export default playerSlice.reducer


### PR DESCRIPTION
- プレイヤーの値をコピーしたオブジェクトでステータスを変更し、最後に一括にプレイヤーのステータスを更新するように修正（敵のターン時、バトル勝利時、プレイヤーアクション時（エナジーの消費、手札の移動））
- プレイヤーのステータスを変更する処理をsliceから別ファイルに移動