### PR TITLE
敗北時にプレイヤーのステータスをリセットする

### DIFF
--- a/client/src/battle/player.ts
+++ b/client/src/battle/player.ts
@@ -38,7 +38,7 @@ export const recoveryEnergy = (player: PlayerType, energy: number): void => {
   player.energy = energy
 }
 
-export const resetPlayerStatus = (player: PlayerType): void => {
+export const resetDefense = (player: PlayerType): void => {
   player.defense = 0
 }
 
@@ -57,4 +57,25 @@ export const moveUsedCardToCemetery = (player: PlayerType, card: CardType): void
 
 export const incrementStage = (player: PlayerType): void => {
   player.stage += 1
+}
+
+export const resetPlayerStatus = (player: PlayerType): void => {
+  resetAttack(player)
+  resetDefense(player)
+  resetStage(player)
+  recoveryEnergy(player, 3)
+  returnCardToDeck(player)
+  initialHp(player)
+}
+
+const resetStage = (player: PlayerType): void => {
+  player.stage = 0
+}
+
+const initialHp = (player: PlayerType): void => {
+  player.hp = player.maxHp
+}
+
+const resetAttack = (player: PlayerType): void => {
+  player.attack = 0
 }

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -23,8 +23,8 @@ import ModalCard from '../components/battle/modalCard'
 import { sleep, isRemainsHp, calcDamage, subtractHp } from '../common/battle'
 import {
   isRemainsEnergy, moveAllNameplateToCemetery, returnCardToDeck,
-  recoveryEnergy, resetPlayerStatus, subtractEnergy, moveUsedCardToCemetery,
-  incrementStage
+  recoveryEnergy, resetDefense, subtractEnergy, moveUsedCardToCemetery,
+  incrementStage, resetPlayerStatus
 } from '../battle/player'
 import { isExistEnemy } from '../battle/enemy'
 import playerImg from '../images/player.png'
@@ -177,15 +177,18 @@ const Battle = (): JSX.Element => {
       const damage = calcDamage(enemy.attack, playerObj.defense)
       subtractHp(playerObj, damage)
     })
-    if (!isRemainsHp(playerObj)) { lose() }
-    enemyTurnEnd(playerObj)
+    if (!isRemainsHp(playerObj)) {
+      lose(playerObj)
+    } else {
+      enemyTurnEnd(playerObj)
+    }
   }
 
   const enemyTurnEnd = (playerObj: PlayerType): void => {
     setIsPlayerTurn(true)
     setDrawButtonDisable(false)
     recoveryEnergy(playerObj, ENERGY_MAX)
-    resetPlayerStatus(playerObj)
+    resetDefense(playerObj)
     dispatch(updatePlayerStatus(playerObj))
   }
 
@@ -201,7 +204,11 @@ const Battle = (): JSX.Element => {
     dispatch(displayRootSelect())
   }
 
-  const lose = (): void => {
+  const lose = (playerObj: PlayerType): void => {
+    resetPlayerStatus(playerObj)
+    dispatch(updatePlayerStatus(playerObj))
+    setIsPlayerTurn(true)
+    setDrawButtonDisable(false)
     dispatch(disableBattle())
     dispatch(displayGameTitle())
   }


### PR DESCRIPTION
- エナジーの回復
- ステージを0にリセット
- カードをデッキに戻す
- HPを最大値に戻す
- 攻撃を0に戻す
- 防御を0に戻す