### PR TITLE
ダメージ計算時に防御力が減るように修正

### DIFF
--- a/client/src/battle/cardEffectList.ts
+++ b/client/src/battle/cardEffectList.ts
@@ -18,5 +18,5 @@ const strike = (player: PlayerType, enemy: EnemyType, card: CardType): void => {
 }
 
 const protection = (player: PlayerType, card: CardType): void => {
-  addBlock(player, card)
+  addBlock(player, card.defense)
 }

--- a/client/src/common/battle.ts
+++ b/client/src/common/battle.ts
@@ -1,13 +1,12 @@
 import { PlayerType, EnemyType, CardType } from '../types/model'
 
 export const playerAttack = (player: PlayerType, enemy: EnemyType, card: CardType): void => {
-  const playerAttackPoint = player.attack + card.attack
-  const damage = calcDamage(playerAttackPoint, enemy.defense)
+  const damage = calcDamage(enemy, player.attack)
   enemy.hp -= damage
 }
 
-export const addBlock = (player: PlayerType, card: CardType): void => {
-  player.defense += card.defense
+export const addBlock = (character: PlayerType | EnemyType, defense: number): void => {
+  character.defense += defense
 }
 
 export const sleep = (msec: number) => new Promise(resolve => setTimeout(resolve, msec))
@@ -26,12 +25,23 @@ export const isRemainsHp = (character: PlayerType | EnemyType): boolean => {
   return character.hp > 0 ? true : false
 }
 
-export const calcDamage = (attackPoint: number, defensePoint: number): number => {
-  const diff = defensePoint - attackPoint
-  const damage = diff < 0 ? Math.abs(diff) : 0
+export const calcDamage = (character: PlayerType | EnemyType, attack: number): number => {
+  let damage = 0
+  const diff = character.defense - attack
+  if (diff < 0) {
+    subtractDefense(character, 0)
+    damage = Math.abs(diff)
+  } else {
+    subtractDefense(character, diff)
+    damage = 0
+  }
   return damage
 }
 
 export const subtractHp = (character: PlayerType | EnemyType, damage: number): void => {
   character.hp -= damage
+}
+
+const subtractDefense = (character: PlayerType | EnemyType, defense: number): void => {
+  character.defense = defense
 }

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -13,14 +13,14 @@ import Modal from '@mui/material/Modal'
 import LinearProgress from '@mui/material/LinearProgress'
 import { EnemyType, CardType, PlayerType } from '../types/model/index'
 import { useAppSelector, useAppDispatch } from '../redux/hooks'
-import { cardDraw, addDefense, recoveryDeck, updatePlayerStatus } from '../redux/slice/playerSlice'
+import { cardDraw, recoveryDeck, updatePlayerStatus } from '../redux/slice/playerSlice'
 import { updateEnemyStatus } from '../redux/slice/fightEnemiesSlice'
 import { displayGameTitle } from '../redux/slice/gameTitleSlice'
 import { displayRootSelect } from '../redux/slice/rootSelectSlice'
 import { disableBattle } from '../redux/slice/battleSlice'
 import Card from '../components/battle/card'
 import ModalCard from '../components/battle/modalCard'
-import { sleep, isRemainsHp, calcDamage, subtractHp } from '../common/battle'
+import { sleep, isRemainsHp, calcDamage, subtractHp, addBlock } from '../common/battle'
 import {
   isRemainsEnergy, moveAllNameplateToCemetery, returnCardToDeck,
   recoveryEnergy, resetDefense, subtractEnergy, moveUsedCardToCemetery,
@@ -152,7 +152,7 @@ const Battle = (): JSX.Element => {
   const playerAction = (enemies: EnemyType[], card: CardType): void => {
     const playerObj: PlayerType = JSON.parse(JSON.stringify(player))
     if (card.actionName === "strike") { enemies[0].hp -= card.attack }
-    if (card.actionName === "protection") { dispatch(addDefense(card.defense)) }
+    if (card.actionName === "protection") { addBlock(playerObj, card.defense) }
     subtractEnergy(playerObj, card.cost)
     moveUsedCardToCemetery(playerObj, card)
     dispatch(updatePlayerStatus(playerObj))
@@ -174,7 +174,7 @@ const Battle = (): JSX.Element => {
   const enemyTurn = async (playerObj: PlayerType): Promise<void> => {
     await sleep(2000)
     fightEnemies.forEach((enemy) => {
-      const damage = calcDamage(enemy.attack, playerObj.defense)
+      const damage = calcDamage(playerObj, enemy.attack)
       subtractHp(playerObj, damage)
     })
     if (!isRemainsHp(playerObj)) {

--- a/client/src/redux/slice/playerSlice.ts
+++ b/client/src/redux/slice/playerSlice.ts
@@ -49,9 +49,6 @@ export const playerSlice = createSlice({
       state.deck = deckShuffle(state.deck)
       state.cemetery = []
     },
-    addDefense: (state, action: PayloadAction<number>) => {
-      state.defense += action.payload
-    },
     updatePlayerStatus: (state, action: PayloadAction<PlayerType>) => action.payload
   }
 })
@@ -61,7 +58,6 @@ export const {
   initialDeck,
   cardDraw,
   recoveryDeck,
-  addDefense,
   updatePlayerStatus
 } = playerSlice.actions
 


### PR DESCRIPTION
- 防御力を減少させる処理の追加
- ダメージ計算時に防御力を減少させるように修正
- ダメージによって防御力が変化し、防御力を超えた攻撃に対して防御力が0になるように設定
- ぼうぎょカード実行時にプレイヤーの値をコピーしたオブジェクトの方のステータスを変更するように修正（直接Stateを更新するのと、コピーを更新するのを一緒にやるとステータスの整合性が取れなくなるため修正した）