### PR TITLE
プレイヤーが受けるダメージを画面に表示する

### DIFF
--- a/client/src/common/uuid.ts
+++ b/client/src/common/uuid.ts
@@ -1,0 +1,5 @@
+export default function uuid() {
+  // ランダムなIDを生成
+  const randomID = Math.random().toString(36).slice(2)
+  return randomID
+}


### PR DESCRIPTION
- プレイヤーのダメージを管理するStateの作成
- ダメージが0未満の時は画面に表示させない
- バトル勝利時、敗北時にダメージをリセットする
- ドロー時、プレイヤーターン終了時にダメージをリセットする（リセットをしないと前のバトルのダメージが画面に表示されてしまう）