### PR TITLE
プレイヤーアクション関数を別ファイルに切り出す

### DIFF
--- a/client/src/battle/player.ts
+++ b/client/src/battle/player.ts
@@ -1,14 +1,12 @@
 import { PlayerType, EnemyType, CardType } from '../types/model/index'
 import { cardEffect } from '../types/battle/cardEffect'
 import { cardEffectList } from './cardEffectList'
+import { isRemainsHp } from '../common/battle'
 
-export const playerAction = (player: PlayerType, enemies: EnemyType[], card: CardType): void => {
-  const cardEffectObj = searchCardEffect(card.actionName)
-  if (cardEffectObj === null) {
-    console.log("実行できるアクションが存在しません")
-    return
-  }
-  cardEffectObj.execution(player, enemies, card)
+export const checkRemainingHp = (enemies: EnemyType[]): void => {
+  enemies.forEach((enemy, index) => {
+    if (!isRemainsHp(enemy)) { enemies.splice(index, 1) }
+  })
 }
 
 export const searchCardEffect = (actionName: string): cardEffect | null => {


### PR DESCRIPTION
- 敵のHPが残っているか確認する関数を別ファイルに切り出した
- プレイヤーアクション関数はダメージ表示の処理があったので、切り出しはせずそのままbattleコンポーネントに残している
- バトル処理時とバトル継続時にステータス更新関数が被らないように条件分岐を追加（dispatchで更新した後にオブジェクトを更新しようとするとread-onlyのエラーが発生する）