### PR TITLE
攻撃をした後に敵を切り替えた時に前回のダメージが表示されてしまう

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -119,8 +119,11 @@ const Battle = (): JSX.Element => {
   }
 
   const enemyImageClick = (num: number): void => {
+    const enemiesObj: EnemyType[] = JSON.parse(JSON.stringify(fightEnemies))
+    enemiesObj.forEach(enemy => enemy.isDamaged = false)
     setChoiceEnemyNumber(num)
     setDisplayPlayerDamage(-1)
+    dispatch(updateEnemyStatus(enemiesObj))
   }
 
   const displayEnemies = (): JSX.Element[] => {


### PR DESCRIPTION
- 前回ダメージが表示されてしまうので、表示されないようにした