### PR TITLE
後ろの敵を倒した時、攻撃する敵が選択されない状態になっている

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -194,6 +194,7 @@ const Battle = (): JSX.Element => {
         if (!isRemainsHp(enemy)) {
           enemiesObj.splice(index, 1)
           setIsEnemyDefeated(true)
+          setChoiceEnemyNumber(0)
         }
       })
       if (!isExistEnemy(enemiesObj)) {


### PR DESCRIPTION
- 後ろの敵を倒したら自動的に先頭の敵を選択するように修正