### PR TITLE
アタッカー専用の初期デッキの作成

### DIFF
--- a/api/app/controllers/api/v1/players_controller.rb
+++ b/api/app/controllers/api/v1/players_controller.rb
@@ -6,6 +6,11 @@ class Api::V1::PlayersController < ApplicationController
 
   def show
     player = Player.find(params[:id])
-    render json: player
+    cards = Card.where(player_id: player.id)
+    result = {
+      player: player,
+      cards: cards
+    }
+    render json: result
   end
 end

--- a/client/src/battle/deck.ts
+++ b/client/src/battle/deck.ts
@@ -1,13 +1,13 @@
 import { CardBaseType, CardType } from '../types/model/index'
-import { deckShuffle } from '../common/battle'
+import { ResCard } from '../types/api/response'
 
-export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
-  let defaultDeck: CardType[] = []
+export const initializeAllPlayerCards = (cardList: CardBaseType[]): CardType[] => {
+  const defaultDeck: CardType[] = []
   let cardId = 1
   const strike: CardBaseType | undefined = cardList.find((card: CardBaseType) => card.name === "ストライク")
   const protection: CardBaseType | undefined = cardList.find((card: CardBaseType) => card.name === "ぼうぎょ")
   if (strike !== undefined) {
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 4; i++) {
       defaultDeck.push({
         id: cardId,
         name: strike.name,
@@ -24,7 +24,7 @@ export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
     }
   }
   if (protection !== undefined) {
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 4; i++) {
       defaultDeck.push({
         id: cardId,
         name: protection.name,
@@ -40,6 +40,42 @@ export const initializeDeck = (cardList: CardBaseType[]): CardType[] => {
       cardId += 1
     }
   }
-  defaultDeck = deckShuffle(defaultDeck)
   return defaultDeck
+}
+
+export const initializeAttackerCards = (attackerCards: ResCard[]): CardType[] => {
+  const resultCards: CardType[] = []
+  let cardId = 8
+  const scorpion: ResCard | undefined = attackerCards.find((card: ResCard) => card.name === "スコーピオン")
+  const moleclaw: ResCard | undefined = attackerCards.find((card: ResCard) => card.name === "モールクロー")
+  if (scorpion !== undefined) {
+    resultCards.push({
+      id: cardId,
+      name: scorpion.name,
+      description: scorpion.description,
+      imageUrl: scorpion.image_url,
+      cost: scorpion.cost,
+      cardType: scorpion.card_type,
+      attack: scorpion.attack,
+      defense: scorpion.defense,
+      actionName: scorpion.action_name,
+      executionCount: scorpion.execution_count
+    })
+    cardId += 1
+  }
+  if (moleclaw !== undefined) {
+    resultCards.push({
+      id: cardId,
+      name: moleclaw.name,
+      description: moleclaw.description,
+      imageUrl: moleclaw.image_url,
+      cost: moleclaw.cost,
+      cardType: moleclaw.card_type,
+      attack: moleclaw.attack,
+      defense: moleclaw.defense,
+      actionName: moleclaw.action_name,
+      executionCount: moleclaw.execution_count
+    })
+  }
+  return resultCards
 }

--- a/client/src/components/gameTitle.tsx
+++ b/client/src/components/gameTitle.tsx
@@ -8,11 +8,12 @@ import CardContent from '@mui/material/CardContent'
 import Grid from '@mui/material/Grid'
 import Button from '@mui/material/Button'
 import Modal from '@mui/material/Modal'
-import { ResPlayer } from '../types/api/response'
+import { ResPlayerCards } from '../types/api/response'
 import { setPlayer, initialDeck } from '../redux/slice/playerSlice'
 import { disableGameTitle } from '../redux/slice/gameTitleSlice'
 import { displayRootSelect } from '../redux/slice/rootSelectSlice'
-import { initializeDeck } from '../battle/deck'
+import { initializeAllPlayerCards, initializeAttackerCards } from '../battle/deck'
+import { deckShuffle } from '../common/battle'
 import playerImg from '../images/player.png'
 import '../styles/battle/style.scss'
 import '../styles/gameTitle/style.scss'
@@ -58,15 +59,14 @@ const GameTitle = (): JSX.Element => {
   }
 
   const getPlayer = async (playerId: number): Promise<void> => {
-    await axiosClient.get('/v1/players', {
-      params: {
-        id: playerId
-      }
-    })
+    await axiosClient.get(`/v1/players/${playerId}`)
     .then(res => {
-      const resPlayer: ResPlayer = res.data
-      const defaultDeck = initializeDeck(cards)
-      dispatch(setPlayer(resPlayer))
+      const resPlayerCards: ResPlayerCards = res.data
+      const allPlayerCards = initializeAllPlayerCards(cards)
+      const attackerCards = initializeAttackerCards(resPlayerCards.cards)
+      let defaultDeck = allPlayerCards.concat(attackerCards)
+      defaultDeck = deckShuffle(defaultDeck)
+      dispatch(setPlayer(resPlayerCards.player))
       dispatch(initialDeck(defaultDeck))
     })
     .catch(error => {

--- a/client/src/types/api/response.d.ts
+++ b/client/src/types/api/response.d.ts
@@ -28,3 +28,8 @@ export type ResCard = {
   action_name: string
   execution_count: number
 }
+
+export type ResPlayerCards = {
+  player: ResPlayer
+  cards: ResCard[]
+}


### PR DESCRIPTION
- プレイヤーを取得するタイミングで一緒にプレイヤーのIDに紐づくカードも取得するようにAPIを修正
- ストライクとぼうぎょを4枚ずつになるように修正
- アタッカーのカードから、スコーピオンとモールクローを取得
- 全てのプレイヤーが使用できるカードとアタッカー専用カードを組み合わせてデッキを作成した