### PR TITLE
全体攻撃時に敵を全滅した時に勝利判定にならない

### DIFF
--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -99,7 +99,7 @@ const Battle = (): JSX.Element => {
   const actionCard = (card: CardType): void => {
     if (isRemainsEnergy(player, card) || playerActionCount > 0) {
       const playerObj: PlayerType = JSON.parse(JSON.stringify(player))
-      const enemiesObj: EnemyType[] = JSON.parse(JSON.stringify(fightEnemies))
+      let enemiesObj: EnemyType[] = JSON.parse(JSON.stringify(fightEnemies))
       playerAction(playerObj, enemiesObj, card)
       if (playerActionCount === 0) {
         subtractEnergy(playerObj, card.cost)
@@ -108,9 +108,9 @@ const Battle = (): JSX.Element => {
       // 連続攻撃のカードの場合に更新
       if (card.executionCount > 1) { dispatch(incrementPlayerActionCount()) }
       // 敵のHPチェック
-      enemiesObj.forEach((enemy, index) => {
+      enemiesObj.forEach(enemy => {
         if (!isRemainsHp(enemy)) {
-          enemiesObj.splice(index, 1)
+          enemiesObj = enemiesObj.filter(enemy => enemy.hp > 0)
           setIsEnemyDefeated(true)
           dispatch(resetChoiceEnemyNumber())
         }


### PR DESCRIPTION
- 全体攻撃で敵を全滅させた時に配列を全削除して勝利判定になるように修正した（HPが0未満の敵を全て摘出するようにした）
- 単体撃破は変わらず倒した敵のみを削除できることを確認