### PR TITLE
勝利後にカードを追加できるようにする

### DIFF
--- a/api/app/controllers/api/v1/players_controller.rb
+++ b/api/app/controllers/api/v1/players_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::PlayersController < ApplicationController
     effect_types = EffectType.all
     card_result = cards.map { |card|
       {
-        id: card.id,
         name: card.name,
         description: card.description,
         image_url: card.image_url,

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { setCards } from './redux/slice/cardsSlice'
 import GameTitle from './components/gameTitle'
 import RootSelect from './components/rootSelect'
 import Battle from './components/battle'
+import Reward from './components/reward'
 
 const App = (): JSX.Element => {
   const dispatch = useAppDispatch()
@@ -43,6 +44,7 @@ const App = (): JSX.Element => {
       <GameTitle />
       <RootSelect />
       <Battle />
+      <Reward />
     </div>
   )
 }

--- a/client/src/battle/deck.ts
+++ b/client/src/battle/deck.ts
@@ -83,3 +83,22 @@ export const initializeAttackerCards = (attackerCards: ResCard[]): CardType[] =>
   }
   return resultCards
 }
+
+export const resCardToCardBase = (resCards: ResCard[]): CardBaseType[] => {
+  const resultCards: CardBaseType[] = []
+  resCards.forEach(card => {
+    resultCards.push({
+      name: card.name,
+      description: card.description,
+      imageUrl: card.image_url,
+      cost: card.cost,
+      cardType: card.card_type,
+      attack: card.attack,
+      defense: card.defense,
+      actionName: card.action_name,
+      executionCount: card.execution_count,
+      effectType: card.effect_type
+    })
+  })
+  return resultCards
+}

--- a/client/src/common/reward.ts
+++ b/client/src/common/reward.ts
@@ -1,0 +1,21 @@
+import { CardBaseType } from '../types/model/index'
+
+export const getDisplayRewardCards = (cards: CardBaseType[]): CardBaseType[] => {
+  const result: CardBaseType[] = []
+  let rewardCards: CardBaseType[] = JSON.parse(JSON.stringify(cards))
+  rewardCards = CardsShuffle(rewardCards)
+  rewardCards.forEach((card, index) => {
+    if (index < 3) { result.push(card) }
+  })
+  return result
+}
+
+const CardsShuffle = (cards: CardBaseType[]): CardBaseType[] => {
+  for (let i = cards.length - 1; i > 0; i--) {
+    const r = Math.floor(Math.random() * (i + 1))
+    const tmp = cards[i]
+    cards[i] = cards[r]
+    cards[r] = tmp
+  }
+  return cards
+}

--- a/client/src/components/battle.tsx
+++ b/client/src/components/battle.tsx
@@ -8,13 +8,13 @@ import { useAppSelector, useAppDispatch } from '../redux/hooks'
 import { updatePlayerStatus } from '../redux/slice/playerSlice'
 import { updateEnemyStatus, resetDamage } from '../redux/slice/fightEnemiesSlice'
 import { displayGameTitle } from '../redux/slice/gameTitleSlice'
-import { displayRootSelect } from '../redux/slice/rootSelectSlice'
 import { disableBattle } from '../redux/slice/battleSlice'
 import { playerTurn } from '../redux/slice/turnSlice'
 import { setPlayerDamage, resetPlayerDamage } from '../redux/slice/playerDamageSlice'
 import { resetChoiceEnemyNumber } from '../redux/slice/choiceEnemySlice'
 import { drawButtonNotDisabled } from '../redux/slice/drawButtonSlice'
 import { incrementPlayerActionCount, resetPlayerActionCount } from '../redux/slice/playerActionCountSlice'
+import { displayReward, setDisplayRewardCards } from '../redux/slice/rewardSlice'
 import Header from './battle/header'
 import DisplayTurn from './battle/displayTurn'
 import Player from './battle/player'
@@ -33,6 +33,7 @@ import {
   initialPlayerStatus, searchCardEffect
 } from '../battle/player'
 import { isExistEnemy } from '../battle/enemy'
+import { getDisplayRewardCards } from '../common/reward'
 import '../styles/battle/style.scss'
 
 const ENERGY_MAX = 3
@@ -62,6 +63,7 @@ const Battle = (): JSX.Element => {
   const choiceEnemyNumber = useAppSelector((state) => state.choiceEnemy)
   const drawButton = useAppSelector((state) => state.drawButton)
   const playerActionCount = useAppSelector((state) => state.playerActionCount)
+  const reward = useAppSelector((state) => state.reward)
   const dispatch = useAppDispatch()
 
   const handleOpen = (): void => setOpen(true)
@@ -202,8 +204,11 @@ const Battle = (): JSX.Element => {
     dispatch(resetChoiceEnemyNumber())
     setEnemyActionCount(0)
     setIsEnemyDefeated(false)
+    // 報酬のカードを設定
+    const rewardDisplayCards = getDisplayRewardCards(reward.cards)
+    dispatch(setDisplayRewardCards(rewardDisplayCards))
     dispatch(disableBattle())
-    dispatch(displayRootSelect())
+    dispatch(displayReward())
   }
 
   const lose = (playerObj: PlayerType): void => {

--- a/client/src/components/gameTitle.tsx
+++ b/client/src/components/gameTitle.tsx
@@ -12,7 +12,8 @@ import { ResPlayerCards } from '../types/api/response'
 import { setPlayer, initialDeck } from '../redux/slice/playerSlice'
 import { disableGameTitle } from '../redux/slice/gameTitleSlice'
 import { displayRootSelect } from '../redux/slice/rootSelectSlice'
-import { initializeAllPlayerCards, initializeAttackerCards } from '../battle/deck'
+import { setRewardCards } from '../redux/slice/rewardSlice'
+import { initializeAllPlayerCards, initializeAttackerCards, resCardToCardBase } from '../battle/deck'
 import { deckShuffle } from '../common/battle'
 import playerImg from '../images/player.png'
 import '../styles/battle/style.scss'
@@ -63,9 +64,11 @@ const GameTitle = (): JSX.Element => {
     .then(res => {
       const resPlayerCards: ResPlayerCards = res.data
       const allPlayerCards = initializeAllPlayerCards(cards)
-      const attackerCards = initializeAttackerCards(resPlayerCards.cards)
-      let defaultDeck = allPlayerCards.concat(attackerCards)
+      const defaultAttackerCards = initializeAttackerCards(resPlayerCards.cards)
+      const attackerCards = resCardToCardBase(resPlayerCards.cards)
+      let defaultDeck = allPlayerCards.concat(defaultAttackerCards)
       defaultDeck = deckShuffle(defaultDeck)
+      dispatch(setRewardCards(attackerCards))
       dispatch(setPlayer(resPlayerCards.player))
       dispatch(initialDeck(defaultDeck))
     })

--- a/client/src/components/reward.tsx
+++ b/client/src/components/reward.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { styled } from '@mui/material/styles'
+import { useAppSelector, useAppDispatch } from '../redux/hooks'
+import Container from '@mui/material/Container'
+import Avatar from '@mui/material/Avatar'
+import Grid from '@mui/material/Grid'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import Modal from '@mui/material/Modal'
+import MuiCard from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardMedia from '@mui/material/CardMedia'
+import CardContent from '@mui/material/CardContent'
+import { CardType, CardBaseType } from '../types/model'
+import { addCard } from '../redux/slice/playerSlice'
+import { displayRootSelect } from '../redux/slice/rootSelectSlice'
+import { disableReward } from '../redux/slice/rewardSlice'
+import playerImg from '../images/player.png'
+import '../styles/reward/style.scss'
+
+const CustomMuiCard = styled(MuiCard)({
+  width: 125,
+  height: 175,
+  margin: "0 auto"
+})
+
+const CustomCardHeader = styled(CardHeader)({
+  color: "white",
+  backgroundColor: "black",
+  height: 30
+})
+
+const CardCost = styled(Avatar)({
+  width: 20,
+  height: 20,
+  backgroundColor: "#42a5f5"
+})
+
+const Reward = (): JSX.Element => {
+  const [open, setOpen] = useState<boolean>(false)
+  const [rewardCard, setRewardCard] = useState<CardBaseType>({
+    name: "",
+    description: "",
+    imageUrl: "",
+    cost: 0,
+    cardType: "",
+    attack: 0,
+    defense: 0,
+    actionName: "",
+    executionCount: 1,
+    effectType: ""
+  })
+
+  const player = useAppSelector((state) => state.player)
+  const reward = useAppSelector((state) => state.reward)
+  const dispatch = useAppDispatch()
+
+  const handleOpen = (): void => setOpen(true)
+  const handleClose = (): void => setOpen(false)
+
+  const selectCard = (card: CardBaseType): void => {
+    setRewardCard(card)
+    handleOpen()
+  }
+
+  const displayRewardCards = (): JSX.Element[] => {
+    return reward.displayCards.map((card, index) =>
+      <Grid item xs={4} key={index}>
+        <CustomMuiCard onClick={() => selectCard(card)}>
+          <CustomCardHeader
+            disableTypography
+            subheader={<Typography variant="body2">{card.name}</Typography>}
+            sx={{ padding: 1 }}
+            avatar={<CardCost>{card.cost}</CardCost>}
+          />
+          <CardMedia
+            component="img"
+            height="55"
+            image={playerImg}
+            alt="カード"
+          />
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              {card.description}
+            </Typography>
+          </CardContent>
+        </CustomMuiCard>
+      </Grid>
+    )
+  }
+
+  const addRewardCard = (): void => {
+    const card: CardType = {
+      id: player.deck.length + 1,
+      name: rewardCard.name,
+      description: rewardCard.description,
+      imageUrl: rewardCard.imageUrl,
+      cost: rewardCard.cost,
+      cardType: rewardCard.cardType,
+      attack: rewardCard.attack,
+      defense: rewardCard.defense,
+      actionName: rewardCard.actionName,
+      executionCount: rewardCard.executionCount,
+      effectType: rewardCard.effectType
+    }
+    dispatch(addCard(card))
+    dispatch(disableReward())
+    dispatch(displayRootSelect())
+    handleClose()
+  }
+
+  const ModalRewardCard = (): JSX.Element => {
+    return (
+      <CustomMuiCard onClick={() => addRewardCard()} className="modal-reward-card">
+        <CustomCardHeader
+          disableTypography
+          subheader={<Typography variant="body2">{rewardCard.name}</Typography>}
+          sx={{ padding: 1 }}
+          avatar={<CardCost>{rewardCard.cost}</CardCost>}
+        />
+        <CardMedia
+          component="img"
+          height="55"
+          image={playerImg}
+          alt="カード"
+        />
+        <CardContent>
+          <Typography variant="body2" color="text.secondary">
+            {rewardCard.description}
+          </Typography>
+        </CardContent>
+      </CustomMuiCard>
+    )
+  }
+
+  const onSkipClick = (): void => {
+    dispatch(disableReward())
+    dispatch(displayRootSelect())
+  }
+
+  return (
+    <div style={{ display: reward.disabled ? 'none' : '' }} className='reward'>
+
+      <Container>
+
+        <div className='reward-message'>
+          <Typography variant='h3'>勝利！</Typography>
+          <Typography variant='subtitle1'>カードを1枚選択してください</Typography>
+        </div>
+
+        <Grid container justifyContent="center" className='reward-cards'>
+          { displayRewardCards() }
+        </Grid>
+
+        <div className='reward-skip'>
+          <Button
+            variant="contained"
+            onClick={onSkipClick}
+          >
+            スキップ
+          </Button>
+        </div>
+
+      </Container>
+
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-reward"
+      >
+        <div id='modal-reward'>
+          <ModalRewardCard />
+        </div>
+      </Modal>
+
+    </div>
+  )
+}
+
+export default Reward

--- a/client/src/components/root_select/circle.tsx
+++ b/client/src/components/root_select/circle.tsx
@@ -1,7 +1,7 @@
 import { useAppSelector, useAppDispatch } from '../../redux/hooks'
 import { setFightEnemies } from '../../redux/slice/fightEnemiesSlice'
 import { disableRootSelect } from '../../redux/slice/rootSelectSlice'
-import { displayBattle } from 'redux/slice/battleSlice'
+import { displayBattle } from '../../redux/slice/battleSlice'
 import { EnemyList } from '../../types/data/enemy'
 import { createEnemyList } from '../../data/enemyList'
 import '../../styles/root_select/style.scss'

--- a/client/src/redux/slice/playerSlice.ts
+++ b/client/src/redux/slice/playerSlice.ts
@@ -36,6 +36,9 @@ export const playerSlice = createSlice({
     initialDeck: (state, action: PayloadAction<CardType[]>) => {
       state.deck = action.payload
     },
+    addCard: (state, action: PayloadAction<CardType>) => {
+      state.deck = state.deck.concat(action.payload)
+    },
     cardDraw: (state, action: PayloadAction<number>) => {
       state.deck.forEach((card, i) => {
         if (i < action.payload) {
@@ -60,6 +63,7 @@ export const playerSlice = createSlice({
 export const {
   setPlayer,
   initialDeck,
+  addCard,
   cardDraw,
   recoveryDeck,
   moveAllNameplateToCemetery,

--- a/client/src/redux/slice/rewardSlice.ts
+++ b/client/src/redux/slice/rewardSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { CardBaseType } from '../../types/model'
+
+type Reward = {
+  disabled: boolean
+  displayCards: CardBaseType[]
+  cards: CardBaseType[]
+}
+
+const initialState: Reward = {
+  disabled: true,
+  displayCards: [],
+  cards: []
+}
+
+export const rewardSlice = createSlice({
+  name: "reward",
+  initialState,
+  reducers: {
+    disableReward: (state) => {
+      state.disabled = true
+    },
+    displayReward: (state) => {
+      state.disabled = false
+    },
+    setDisplayRewardCards: (state, action: PayloadAction<CardBaseType[]>) => {
+      state.displayCards = action.payload
+    },
+    setRewardCards: (state, action: PayloadAction<CardBaseType[]>) => {
+      state.cards = action.payload
+    }
+  }
+})
+
+export const { disableReward, displayReward, setDisplayRewardCards, setRewardCards} = rewardSlice.actions
+
+export default rewardSlice.reducer

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -11,6 +11,7 @@ import playerDamageReducer from './slice/playerDamageSlice'
 import choiceEnemyReducer from './slice/choiceEnemySlice'
 import drawButtonReducer from './slice/drawButtonSlice'
 import playerActionCountReducer from './slice/playerActionCountSlice'
+import rewardReducer from './slice/rewardSlice'
 
 export const store = configureStore({
   reducer: {
@@ -25,7 +26,8 @@ export const store = configureStore({
     playerDamage: playerDamageReducer,
     choiceEnemy: choiceEnemyReducer,
     drawButton: drawButtonReducer,
-    playerActionCount: playerActionCountReducer
+    playerActionCount: playerActionCountReducer,
+    reward: rewardReducer
   }
 })
 

--- a/client/src/styles/reward/style.scss
+++ b/client/src/styles/reward/style.scss
@@ -1,0 +1,25 @@
+.reward {
+  margin-top: 30px;
+}
+
+.reward-message {
+  text-align: center;
+}
+
+.reward-cards {
+  margin-top: 50px;
+}
+
+.reward-skip {
+  margin-top: 50px;
+  text-align: center;
+}
+
+.modal-reward-card {
+  width: 50%;
+  height: 50%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
- 報酬画面の作成
- 報酬カード（プレイヤー固有のカード全て）をプレイヤー選択時に取得する
- 勝利時に報酬カードの中から3枚ランダムで表示する
- 3枚のうち1枚を選択してデッキに追加できるようにした
- スキップした場合は何もせずルート選択画面に遷移する