### PR TITLE
ドロー時に5枚以下だったら先に残っているカードをドローする

### DIFF
--- a/client/src/components/battle/drawButton.tsx
+++ b/client/src/components/battle/drawButton.tsx
@@ -10,10 +10,13 @@ const DrawButton = (): JSX.Element => {
 
   const onClickDraw = (): void => {
     const drawNum = 5
+    let nowNameplateLength = 0
     if (player.deck.length < drawNum) {
+      nowNameplateLength = player.deck.length
+      dispatch(cardDraw(player.deck.length))
       dispatch(recoveryDeck())
     }
-    dispatch(cardDraw(drawNum))
+    dispatch(cardDraw(drawNum - nowNameplateLength))
     dispatch(drawButtonDisabled())
   }
 


### PR DESCRIPTION
- デッキが5枚以下の場合、デッキに残っているカードを先にドローするように修正
- 手札が5枚になるようにドローするように修正（先にカードをドローした枚数を考慮した）