### PR TITLE
allプレイヤー用追加カードの効果を追加

### DIFF
--- a/client/src/battle/cardEffect/all/skill.ts
+++ b/client/src/battle/cardEffect/all/skill.ts
@@ -1,6 +1,22 @@
 import { CardEffectProps } from '../../../types/battle/cardEffect'
-import { guard } from '../../../common/cardEffect'
+import { guard, cardDraw } from '../../../common/cardEffect'
+import { addBlock } from '../../../common/battle'
 
 export const protection = (props: CardEffectProps): void => {
   guard(props)
+}
+
+export const escudo = (props: CardEffectProps): void => {
+  if (props.type === "guard") {
+    const { player, card } = props
+    addBlock(player, card.defense)
+  }
+}
+
+export const grasshopper = (props: CardEffectProps): void => {
+  if (props.type === "guard") {
+    const { player, card } = props
+    addBlock(player, card.defense)
+    cardDraw(player, 1)
+  }
 }

--- a/client/src/battle/cardEffect/cardEffectList.ts
+++ b/client/src/battle/cardEffect/cardEffectList.ts
@@ -1,7 +1,7 @@
 import { CardEffectProps } from '../../types/battle/cardEffect'
 import { cardEffect } from '../../types/battle/cardEffect'
 import { strike } from './all/attack'
-import { protection } from './all/skill'
+import { protection, escudo, grasshopper } from './all/skill'
 import { scorpion, moleclaw, mantis, sword, raygust, thruster } from './attacker/attack'
 import { asteroid, meteora, viper, hound, grenade } from './shooter/attack'
 import { eagred, lightning, ibis } from './sniper/attack'
@@ -70,5 +70,13 @@ export const cardEffectList: cardEffect[] = [
   {
     name: "ibis",
     execution: (props: CardEffectProps): void => ibis(props)
+  },
+  {
+    name: "escudo",
+    execution: (props: CardEffectProps): void => escudo(props)
+  },
+  {
+    name: "grasshopper",
+    execution: (props: CardEffectProps): void => grasshopper(props)
   }
 ]

--- a/client/src/common/cardEffect.ts
+++ b/client/src/common/cardEffect.ts
@@ -1,3 +1,4 @@
+import { PlayerType } from '../types/model'
 import { CardEffectProps } from '../types/battle/cardEffect'
 import { addBlock } from './battle'
 import { playerAttack, randomPlayerAttack, playerBlockAttack } from '../battle/player'
@@ -52,4 +53,11 @@ export const oneAttackAndBlockAttack = (props: CardEffectProps): void => {
     const damage = playerAttack(player, enemy, card)
     setDamage(enemy, damage)
   }
+}
+
+export const cardDraw = (player: PlayerType, num: number): void => {
+  player.deck.forEach((card, i) => {
+    if (i < num) { player.nameplate.push(card) }
+  })
+  player.deck.splice(0, num)
 }


### PR DESCRIPTION
- エスクードとグラスホッパーを追加
- カード効果名の関数内でカードの効果を実行するように修正（階層をひとつ上げた）