### PR TITLE
1階の敵のパターンリストを作成

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,18 @@
 import { useEffect } from 'react'
 import axiosClient from './api/axios'
 import { ResEnemies, ResCard } from './types/api/response'
-import { useAppDispatch } from './redux/hooks'
+import { useAppDispatch, useAppSelector } from './redux/hooks'
 import { setEnemies } from './redux/slice/enemiesSlice'
 import { setCards } from './redux/slice/cardsSlice'
+import { setEnemyList } from './redux/slice/enemyListSlice'
 import GameTitle from './components/gameTitle'
 import RootSelect from './components/rootSelect'
 import Battle from './components/battle'
 import Reward from './components/reward'
+import { createEnemyList } from './data/enemyList'
 
 const App = (): JSX.Element => {
+  const enemies = useAppSelector((state) => state.enemies)
   const dispatch = useAppDispatch()
 
   const getEnemies = async (): Promise<void> => {
@@ -38,6 +41,11 @@ const App = (): JSX.Element => {
     getEnemies()
     getCards()
   }, [])
+
+  useEffect((): void => {
+    // 今後フロアが切り替わったらリストを更新するようにする
+    dispatch(setEnemyList(createEnemyList(enemies)))
+  }, [enemies])
 
   return (
     <div>

--- a/client/src/components/root_select/circle.tsx
+++ b/client/src/components/root_select/circle.tsx
@@ -2,8 +2,6 @@ import { useAppSelector, useAppDispatch } from '../../redux/hooks'
 import { setFightEnemies } from '../../redux/slice/fightEnemiesSlice'
 import { disableRootSelect } from '../../redux/slice/rootSelectSlice'
 import { displayBattle } from '../../redux/slice/battleSlice'
-import { EnemyList } from '../../types/data/enemy'
-import { createEnemyList } from '../../data/enemyList'
 import '../../styles/root_select/style.scss'
 
 type Props = {
@@ -15,7 +13,7 @@ type Props = {
 const Circle = (props: Props): JSX.Element => {
   const { left, top, rootNumber } = props
   const player = useAppSelector((state) => state.player)
-  const enemies = useAppSelector((state) => state.enemies)
+  const enemyList = useAppSelector((state) => state.enemyList)
   const dispatch = useAppDispatch()
 
   const battleStart = (): void => {
@@ -28,25 +26,24 @@ const Circle = (props: Props): JSX.Element => {
   }
 
   const decisionFightEnemies = (): void => {
-    const enemyList: EnemyList = createEnemyList(enemies)
     switch (rootNumber) {
       case 0:
-        dispatch(setFightEnemies(enemyList.slime))
+        dispatch(setFightEnemies(enemyList.stage1))
         break
       case 1:
-        dispatch(setFightEnemies(enemyList.gargoyle))
+        dispatch(setFightEnemies(enemyList.stage2))
         break
       case 2:
-        dispatch(setFightEnemies(enemyList.slimeAndGargoyle))
+        dispatch(setFightEnemies(enemyList.stage3))
         break
       case 3:
-        dispatch(setFightEnemies(enemyList.slimeAndGargoyle))
+        dispatch(setFightEnemies(enemyList.stage4))
         break
       case 4:
-        dispatch(setFightEnemies(enemyList.slimeAndGargoyle))
+        dispatch(setFightEnemies(enemyList.stage5))
         break
       case 5:
-        dispatch(setFightEnemies(enemyList.slimeAndGargoyle))
+        dispatch(setFightEnemies(enemyList.stage6))
         break
     }
   }

--- a/client/src/data/enemyList.ts
+++ b/client/src/data/enemyList.ts
@@ -1,16 +1,43 @@
 import { EnemyType } from '../types/model/index'
-import { EnemyList } from '../types/data/enemy'
+import { EnemyList, EnemyPattern } from '../types/data/enemy'
 
 export const createEnemyList = (enemies: EnemyType[]): EnemyList => {
+  const enemyPattern = floorOneEnemyPattern(enemies)
   const enemyList: EnemyList = {
-    slime: [],
-    gargoyle: [],
-    slimeAndGargoyle: []
+    stage1: [],
+    stage2: [],
+    stage3: [],
+    stage4: [],
+    stage5: [],
+    stage6: []
   }
-  enemyList.slime = enemyList.slime.concat(searchEnemy(enemies, ["スライム"]))
-  enemyList.gargoyle = enemyList.gargoyle.concat(searchEnemy(enemies, ["ガーゴイル"]))
-  enemyList.slimeAndGargoyle = enemyList.slimeAndGargoyle.concat(searchEnemy(enemies, ["スライム", "ガーゴイル"]))
+  enemyList.stage1 = enemyList.stage1.concat(enemyPattern.pattern1)
+  enemyList.stage2 = enemyList.stage2.concat(enemyPattern.pattern2)
+  enemyList.stage3 = enemyList.stage3.concat(enemyPattern.pattern3)
+  enemyList.stage4 = enemyList.stage4.concat(enemyPattern.pattern4)
+  enemyList.stage5 = enemyList.stage5.concat(enemyPattern.pattern5)
+  enemyList.stage6 = enemyList.stage6.concat(enemyPattern.pattern6)
   return enemyList
+}
+
+const floorOneEnemyPattern = (enemies: EnemyType[]): EnemyPattern => {
+  const enemyPattern: EnemyPattern = {
+    pattern1: [],
+    pattern2: [],
+    pattern3: [],
+    pattern4: [],
+    pattern5: [],
+    pattern6: [],
+    pattern7: []
+  }
+  enemyPattern.pattern1 = enemyPattern.pattern1.concat(searchEnemy(enemies, ["スライム"]))
+  enemyPattern.pattern2 = enemyPattern.pattern2.concat(searchEnemy(enemies, ["スライム", "ガーゴイル"]))
+  enemyPattern.pattern3 = enemyPattern.pattern3.concat(searchEnemy(enemies, ["グレムリン"]))
+  enemyPattern.pattern4 = enemyPattern.pattern4.concat(searchEnemy(enemies, ["盗賊", "盗賊"]))
+  enemyPattern.pattern5 = enemyPattern.pattern5.concat(searchEnemy(enemies, ["ガーゴイル", "グレムリン"]))
+  enemyPattern.pattern6 = enemyPattern.pattern6.concat(searchEnemy(enemies, ["キメラ"]))
+  enemyPattern.pattern7 = enemyPattern.pattern7.concat(searchEnemy(enemies, ["ボススライム"]))
+  return enemyPattern
 }
 
 const searchEnemy = (enemies: EnemyType[], searchTextList: Array<string>): EnemyType[] => {

--- a/client/src/redux/slice/enemiesSlice.ts
+++ b/client/src/redux/slice/enemiesSlice.ts
@@ -20,7 +20,9 @@ export const enemiesSlice = createSlice({
           maxHp: resEnemy.hp,
           attack: resEnemy.attack,
           defense: resEnemy.defense,
-          damage: -1
+          damage: -1,
+          floorNumber: resEnemy.floor_number,
+          isBoss: resEnemy.is_boss
         }
         state.push(enemy)
       })

--- a/client/src/redux/slice/enemyListSlice.ts
+++ b/client/src/redux/slice/enemyListSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { EnemyList } from '../../types/data/enemy'
+
+// Stateの初期値
+const initialState: EnemyList = {
+  stage1: [],
+  stage2: [],
+  stage3: [],
+  stage4: [],
+  stage5: [],
+  stage6: []
+}
+
+// State, Action, Reducersの管理
+export const enemyListSlice = createSlice({
+  name: 'enemyList',
+  initialState,
+  reducers: {
+    setEnemyList: (state, action: PayloadAction<EnemyList>) => action.payload
+  }
+})
+
+export const { setEnemyList } = enemyListSlice.actions
+
+export default enemyListSlice.reducer

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -13,6 +13,7 @@ import drawButtonReducer from './slice/drawButtonSlice'
 import playerActionCountReducer from './slice/playerActionCountSlice'
 import rewardReducer from './slice/rewardSlice'
 import enemyDefeatedReducer from './slice/enemyDefeatedSlice'
+import enemyListReducer from './slice/enemyListSlice'
 
 export const store = configureStore({
   reducer: {
@@ -29,7 +30,8 @@ export const store = configureStore({
     drawButton: drawButtonReducer,
     playerActionCount: playerActionCountReducer,
     reward: rewardReducer,
-    enemyDefeated: enemyDefeatedReducer
+    enemyDefeated: enemyDefeatedReducer,
+    enemyList: enemyListReducer
   }
 })
 

--- a/client/src/types/api/response.d.ts
+++ b/client/src/types/api/response.d.ts
@@ -15,6 +15,8 @@ export type ResEnemies = {
   hp: number
   attack: number
   defense: number
+  floor_number: number
+  is_boss: boolean
 }
 
 export type ResCard = {

--- a/client/src/types/data/enemy.d.ts
+++ b/client/src/types/data/enemy.d.ts
@@ -1,5 +1,18 @@
 export type EnemyList = {
-  slime: EnemyType[]
-  gargoyle: EnemyType[]
-  slimeAndGargoyle: EnemyType[]
+  stage1: EnemyType[]
+  stage2: EnemyType[]
+  stage3: EnemyType[]
+  stage4: EnemyType[]
+  stage5: EnemyType[]
+  stage6: EnemyType[]
+}
+
+export type EnemyPattern = {
+  pattern1: EnemyType[]
+  pattern2: EnemyType[]
+  pattern3: EnemyType[]
+  pattern4: EnemyType[]
+  pattern5: EnemyType[]
+  pattern6: EnemyType[]
+  pattern7: EnemyType[]
 }

--- a/client/src/types/model/index.d.ts
+++ b/client/src/types/model/index.d.ts
@@ -7,6 +7,8 @@ export type EnemyType = {
   attack: number
   defense: number
   damage: number
+  floorNumber: number
+  isBoss: boolean
 }
 
 export type PlayerType = {


### PR DESCRIPTION
- 1階で出現する敵の出現パターンを作成
- 1階のステージ毎に出現パターンを当てはめていく（ステージ1にはパターン1をみたいな）
- APIから敵データを取得した後に、ステージ毎に出現する敵の設定をする（前はルートを選択するたびにリストの作成を行なっていて処理が冗長だった）
- 1階の敵が決められたステージに設定されていることを確認