### PR TITLE
allプレイヤー用カードの取得APIのテストを作成

### DIFF
--- a/api/app/controllers/api/v1/cards_controller.rb
+++ b/api/app/controllers/api/v1/cards_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::CardsController < ApplicationController
   def index
-    player = Player.find(1)
+    player = Player.find_by(name: "all")
     cards = Card.where(player_id: player.id)
     effect_types = EffectType.all
     card_result = cards.map { |card|

--- a/api/spec/factories/card.rb
+++ b/api/spec/factories/card.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :card do
+    name { 'ストライク' }
+    description { '6ダメージを与える' }
+    image_url { 'none' }
+    cost { 1 }
+    card_type { 'アタック' }
+    attack { 6 }
+    defense { 0 }
+    action_name { 'strike' }
+    execution_count { 1 }
+  end
+end

--- a/api/spec/factories/effect_type.rb
+++ b/api/spec/factories/effect_type.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :effect_type do
+    name { 'oneAttack' }
+  end
+end

--- a/api/spec/factories/player.rb
+++ b/api/spec/factories/player.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :player do
+    name { 'all' }
+    image_url { 'none' }
+    hp { 80 }
+    attack { 0 }
+    defense { 0 }
+    energy { 3 }
+  end
+end

--- a/api/spec/requests/api/v1/cards_spec.rb
+++ b/api/spec/requests/api/v1/cards_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'CardsAPI' do
+  it 'allプレイヤーのカードを取得する' do
+    player = FactoryBot.create(:player)
+    effect_type = FactoryBot.create(:effect_type)
+    FactoryBot.create(:card, player_id: player.id, effect_type_id: effect_type.id)
+
+    get '/api/v1/cards'
+    json = JSON.parse(response.body)
+
+    expect(response.status).to eq(200)
+    expect(json[0]['name']).to eq('ストライク')
+  end
+end


### PR DESCRIPTION
- カードのテストデータを作成
- レスポンスステータスのテスト
- テストデータの名前を比較して、一致しているか確認する
- カードのコントローラーの処理を変更（プレイヤー名で検索をかけるようにした。idだとデータの更新、削除があった場合に対応できない）