### PR TITLE
404エラーページの設定

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -119,7 +119,7 @@ http {
     # ルートディレクトリにアクセスした時
     location / {
       # 指定のファイルが存在するかチェック
-      try_files $uri $uri.html $uri/index.html;
+      try_files $uri $uri.html $uri/index.html $uri =404;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }
@@ -133,7 +133,7 @@ http {
       proxy_pass http://api;
     }
 
-    error_page  404 /404.html;
+    error_page  404 /index.html;
     error_page  500 502 503 504 /50x.html;
   }
 }


### PR DESCRIPTION
- nginx.confの修正
　- urlが一致しない場合に404エラーページを呼び出すように設定
　-  404ページをindex.htmlに設定（client側で404エラーページを表示させる）