### PR TITLE
本番環境用のpuma設定ファイルを修正

### DIFF
--- a/api/config/puma/production.rb
+++ b/api/config/puma/production.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+# port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
- puma.sockを自動生成させるためにポート番号の指定をコメントアウト