### PR TITLE
puma.sockを正しく参照するように修正

### DIFF
--- a/api/config/puma/production.rb
+++ b/api/config/puma/production.rb
@@ -36,7 +36,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-app_root = File.expand_path("../..", __FILE__)
+app_root = File.expand_path("../../..", __FILE__)
 bind "unix://#{app_root}/tmp/sockets/puma.sock"
 
 if ENV.fetch("RAILS_ENV", "development") == "production"


### PR DESCRIPTION
- 本番環境用
- 開発と本番でディレクトリの位置が異なるので、環境に合わせて参照するディレクトリを修正