### PR TITLE
corsにドメインからのアクセスを許可させる

### DIFF
--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:3333', 'http://localhost:8080'
+    origins 'http://localhost:3333', 'http://localhost:8080', 'https://end-of-the-tower.net'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
- ドメインからapiへのアクセスを許可するために、corsにドメインを追加する