### PR TITLE
バトル画面の高さが変動しないようにする

### DIFF
--- a/client/src/styles/battle/style.scss
+++ b/client/src/styles/battle/style.scss
@@ -51,7 +51,6 @@
 }
 
 .card-list {
-  margin-top: 30px;
   justify-content: center;
 }
 


### PR DESCRIPTION
- 手札のマージンを無くした